### PR TITLE
Implement live container start/stop

### DIFF
--- a/backend/events.go
+++ b/backend/events.go
@@ -1,0 +1,91 @@
+package backend
+
+import (
+	"net/http/httputil"
+	"net/http"
+	"encoding/json"
+	"bufio"
+
+	"github.com/mijara/statspout/log"
+)
+
+type Event struct {
+	Type   string `json:"Type"`
+	Action string `json:"Action"`
+	Actor struct {
+		Attributes struct {
+			Name string `json:"name"`
+		} `json:"Attributes"`
+	} `json:"Actor"`
+}
+
+type EventsMonitor struct {
+	client *httputil.ClientConn
+	quit   chan bool
+}
+
+func NewEventsMonitor(http bool, address string) (*EventsMonitor, error) {
+	conn, err := createConn(http, address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventsMonitor{
+		client: httputil.NewClientConn(conn, nil),
+	}, nil
+}
+
+func (em *EventsMonitor) monitor(containers map[string]bool) {
+	em.quit = make(chan bool, 1)
+	go em.loop(containers)
+}
+
+func (em *EventsMonitor) Close() {
+	em.quit <- true
+}
+
+func (em *EventsMonitor) loop(containers map[string]bool) {
+	req, err := http.NewRequest("GET", "/events", nil)
+	if err != nil {
+		log.Error.Printf("Could not monitor events: %s", err.Error())
+	}
+
+	res, err := em.client.Do(req)
+	if err != nil {
+		log.Error.Printf("Events request failed: %s", err.Error())
+	}
+	defer res.Body.Close()
+
+	reader := bufio.NewReader(res.Body)
+
+	for {
+		select {
+		case <-em.quit:
+			return
+		default:
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				log.Error.Printf("Events response error: %s", err.Error())
+			}
+
+			event := Event{}
+			err = json.Unmarshal(line, &event)
+			if err != nil {
+				log.Error.Printf("Events response error: %s", err.Error())
+			}
+
+			if event.Type == "container" {
+				switch event.Action {
+				case "stop":
+					log.Info.Printf("Container %s stopped.", event.Actor.Attributes.Name)
+
+					delete(containers, event.Actor.Attributes.Name)
+				case "start":
+					log.Info.Printf("Container %s started.", event.Actor.Attributes.Name)
+
+					containers[event.Actor.Attributes.Name] = true
+				}
+			}
+		}
+	}
+}

--- a/backend/util.go
+++ b/backend/util.go
@@ -1,5 +1,16 @@
 package backend
 
+import "net"
+
+// Creates a client for TCP (http) or Unix with the given address.
+func createConn(http bool, address string) (net.Conn, error) {
+	if http {
+		return net.Dial("tcp", address)
+	}
+
+	return net.Dial("unix", address)
+}
+
 // taken from: https://github.com/portainer/portainer/blob/develop/app/components/stats/statsController.js#L177-L193
 func calcCpuPercent(stats *ContainerStats) float64 {
 	cpuPercent := 0.0

--- a/log/log.go
+++ b/log/log.go
@@ -12,7 +12,7 @@ var (
 )
 
 func init() {
-	Info = log.New(os.Stdout, "INFO: ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
-	Error = log.New(os.Stderr, "ERROR: ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
-	Debug = log.New(os.Stdout, "DEBUG: ", log.LstdFlags|log.Lmicroseconds|log.Lshortfile)
+	Info = log.New(os.Stdout, "INFO: ", log.LstdFlags|log.Lmicroseconds)
+	Error = log.New(os.Stderr, "ERROR: ", log.LstdFlags|log.Lmicroseconds)
+	Debug = log.New(os.Stdout, "DEBUG: ", log.LstdFlags|log.Lmicroseconds)
 }


### PR DESCRIPTION
The system connects to the docker events API and listens for start/stop events in order to live reload containers list for the next fetch cycle.