### PR TITLE
Track Disk IO

### DIFF
--- a/backend/util.go
+++ b/backend/util.go
@@ -42,3 +42,13 @@ func sumRxBytesTotal(interfaces map[string]InterfaceStats) (sum uint32) {
 	}
 	return
 }
+
+func getOpValue(container *ContainerStats, name string) int {
+	for _, op := range container.BlockIO.ServiceBytesRecursive {
+		if op.Op == name {
+			return op.Value
+		}
+	}
+
+	return 0
+}

--- a/common/influxdb.go
+++ b/common/influxdb.go
@@ -52,6 +52,14 @@ func (influx *InfluxDB) Push(s *stats.Stats) error {
 		return err
 	}
 
+	if err := influx.pushResource(s, "blkio_read", s.BlockIOBytesRead); err != nil {
+		return err
+	}
+
+	if err := influx.pushResource(s, "blkio_write", s.BlockIOBytesWrite); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -32,12 +32,16 @@ type Stats struct {
 	// Transmit and Receive network stats, in bytes.
 	TxBytesTotal uint32 `json:"tx_bytes"`
 	RxBytesTotal uint32 `json:"rx_bytes"`
+
+	BlockIOBytesRead  int `json:"blkio_read"`
+	BlockIOBytesWrite int `json:"blkio_write"`
 }
 
 // Prints stats in a nice format.
 func (stats *Stats) String() string {
-	return fmt.Sprintf("[%s] {%s} CPU: %f%%, MEM: %f%% [%d B] Tx/Rx: %d/%d",
+	return fmt.Sprintf("[%s] {%s} CPU: %f%%, MEM: %f%% [%d B] Tx/Rx: %d/%d, IO R/W: %d/%d",
 		stats.Name, stats.Timestamp.Format("02 Jan 06 15:04:05 MST"),
 		stats.CpuPercent, stats.MemoryPercent, stats.MemoryUsage,
-		stats.TxBytesTotal, stats.RxBytesTotal)
+		stats.TxBytesTotal, stats.RxBytesTotal,
+		stats.BlockIOBytesRead, stats.BlockIOBytesWrite)
 }


### PR DESCRIPTION
This PR implements Disk IO in bytes, supporting:

- Block IO Read and Write in Bytes
- Support for InfluxDB and Prometheus Block IO storage, as: `blkio_read` and `blkio_write`
